### PR TITLE
Fixed a typo in the category names

### DIFF
--- a/src/fixtures/services.js
+++ b/src/fixtures/services.js
@@ -2481,7 +2481,7 @@ const services = [
     locations: [
       'National'
     ],
-    category: 'VIihde'
+    category: 'Viihde'
   },
   {
     id: '',


### PR DESCRIPTION
Typofix: VIihde -> Viihde
Caused a category to display as duplicate.